### PR TITLE
Fixed ObjectCollection.cs to lay out from the left top to the bottom right.

### DIFF
--- a/DesignLabs_Unity/Assets/MRDesignLab/HUX/Scripts/Collections/ObjectCollection.cs
+++ b/DesignLabs_Unity/Assets/MRDesignLab/HUX/Scripts/Collections/ObjectCollection.cs
@@ -270,7 +270,7 @@ namespace HUX.Collections
                         {
                             if (cellCounter < NodeList.Count)
                             {
-                                nodeGrid[cellCounter] = new Vector3((c * CellWidth) - startOffsetX + _halfCell.x, (r * CellHeight) - startOffsetY + _halfCell.y, 0f) + (Vector3)((CollectionNode)(NodeList[cellCounter])).Offset;
+                                nodeGrid[cellCounter] = new Vector3((c * CellWidth) - startOffsetX + _halfCell.x, -(r * CellHeight) + startOffsetY - _halfCell.y, 0f) + (Vector3)((CollectionNode)(NodeList[cellCounter])).Offset;
                             }
                             cellCounter++;
                         }
@@ -284,7 +284,7 @@ namespace HUX.Collections
                         {
                             if (cellCounter < NodeList.Count)
                             {
-                                nodeGrid[cellCounter] = new Vector3((c * CellWidth) - startOffsetX + _halfCell.x, (r * CellHeight) - startOffsetY + _halfCell.y, 0f) + (Vector3)((CollectionNode)(NodeList[cellCounter])).Offset;
+                                nodeGrid[cellCounter] = new Vector3((c * CellWidth) - startOffsetX + _halfCell.x, -(r * CellHeight) + startOffsetY - _halfCell.y, 0f) + (Vector3)((CollectionNode)(NodeList[cellCounter])).Offset;
                             }
                             cellCounter++;
                         }
@@ -454,7 +454,7 @@ namespace HUX.Collections
             Vector3 newPos = new Vector3(0f, 0f, Radius);
 
             float xAngle = (source.x / _circ) * 360f;
-            float yAngle = (source.y / _circ) * 360f;
+            float yAngle = -(source.y / _circ) * 360f;
 
             Quaternion rot = Quaternion.Euler(yAngle, xAngle, 0.0f);
             newPos = rot * newPos;

--- a/DesignLabs_Unity_Examples/Assets/MRDesignLab/HUX/Scripts/Collections/ObjectCollection.cs
+++ b/DesignLabs_Unity_Examples/Assets/MRDesignLab/HUX/Scripts/Collections/ObjectCollection.cs
@@ -270,7 +270,7 @@ namespace HUX.Collections
                         {
                             if (cellCounter < NodeList.Count)
                             {
-                                nodeGrid[cellCounter] = new Vector3((c * CellWidth) - startOffsetX + _halfCell.x, (r * CellHeight) - startOffsetY + _halfCell.y, 0f) + (Vector3)((CollectionNode)(NodeList[cellCounter])).Offset;
+                                nodeGrid[cellCounter] = new Vector3((c * CellWidth) - startOffsetX + _halfCell.x, -(r * CellHeight) + startOffsetY - _halfCell.y, 0f) + (Vector3)((CollectionNode)(NodeList[cellCounter])).Offset;
                             }
                             cellCounter++;
                         }
@@ -284,7 +284,7 @@ namespace HUX.Collections
                         {
                             if (cellCounter < NodeList.Count)
                             {
-                                nodeGrid[cellCounter] = new Vector3((c * CellWidth) - startOffsetX + _halfCell.x, (r * CellHeight) - startOffsetY + _halfCell.y, 0f) + (Vector3)((CollectionNode)(NodeList[cellCounter])).Offset;
+                                nodeGrid[cellCounter] = new Vector3((c * CellWidth) - startOffsetX + _halfCell.x, -(r * CellHeight) + startOffsetY - _halfCell.y, 0f) + (Vector3)((CollectionNode)(NodeList[cellCounter])).Offset;
                             }
                             cellCounter++;
                         }
@@ -454,7 +454,7 @@ namespace HUX.Collections
             Vector3 newPos = new Vector3(0f, 0f, Radius);
 
             float xAngle = (source.x / _circ) * 360f;
-            float yAngle = (source.y / _circ) * 360f;
+            float yAngle = -(source.y / _circ) * 360f;
 
             Quaternion rot = Quaternion.Euler(yAngle, xAngle, 0.0f);
             newPos = rot * newPos;


### PR DESCRIPTION
Hello.

I think that the NodeList of ObjectCollection is better to lay out from the left top to the bottom right. 
When surface type property of ObjectCollection is "Plane" and "Cylinder",it lay out the NodeList from the left bottom to the top right.  
But that is a layout of different than usual, so it not intuitive.

Please refer if you do not mind.
Regards.