### PR TITLE
Fixed the refresh method of BoundingBox's Bounds

### DIFF
--- a/DesignLabs_Unity/Assets/MRDesignLab/HUX/Scripts/Interaction/BoundingBox.cs
+++ b/DesignLabs_Unity/Assets/MRDesignLab/HUX/Scripts/Interaction/BoundingBox.cs
@@ -142,18 +142,14 @@ namespace HUX.Interaction
             // Get the new target bounds
             boundsPoints.Clear();
 
-            MeshFilter[] mfs = target.GetComponentsInChildren<MeshFilter>();
-            foreach (MeshFilter mf in mfs)
+            Renderer[] renderers = target.GetComponentsInChildren<Renderer>();
+            for(int i =0; i<renderers.Length; ++i)
             {
-                if (mf.gameObject.layer == IgnoreLayer)
+                var rendererObj = renderers[i];
+                if(rendererObj.gameObject.layer == IgnoreLayer)
                     continue;
 
-                Vector3 v3Center = mf.sharedMesh.bounds.center;
-                Vector3 v3Extents = mf.sharedMesh.bounds.extents;
-
-                // Get the world-space corner points of the bounds
-                // Add them to our global list of points
-                mf.sharedMesh.bounds.GetCornerPositions(mf.transform, ref corners);
+                rendererObj.bounds.GetCornerPositionsFromRendererBounds(ref corners);
                 boundsPoints.AddRange(corners);
             }
 

--- a/DesignLabs_Unity/Assets/MRDesignLab/HUX/Scripts/Utility/BoundsExtentions.cs
+++ b/DesignLabs_Unity/Assets/MRDesignLab/HUX/Scripts/Utility/BoundsExtentions.cs
@@ -94,6 +94,38 @@ public static class BoundsExtentions
         positions[BoundsExtentions.RTB] = transform.TransformPoint(rightEdge, topEdge, backEdge);
     }
 
+    /// <summary>
+    /// Gets all the corner points from Renderer's Bounds
+    /// </summary>
+    /// <param name="bounds"></param>
+    /// <param name="positions"></param>
+    public static void GetCornerPositionsFromRendererBounds(this Bounds bounds, ref Vector3[] positions)
+    {
+        Vector3 center = bounds.center;
+        Vector3 extents = bounds.extents;
+        float leftEdge = center.x - extents.x;
+        float rightEdge = center.x + extents.x;
+        float bottomEdge = center.y - extents.y;
+        float topEdge = center.y + extents.y;
+        float frontEdge = center.z - extents.z;
+        float backEdge = center.z + extents.z;
+
+        const int numPoints = 8;
+        if(positions == null || positions.Length != numPoints)
+        {
+            positions = new Vector3[numPoints];
+        }
+
+        positions[BoundsExtentions.LBF] = new Vector3(leftEdge, bottomEdge, frontEdge);
+        positions[BoundsExtentions.LBB] = new Vector3(leftEdge, bottomEdge, backEdge);
+        positions[BoundsExtentions.LTF] = new Vector3(leftEdge, topEdge, frontEdge);
+        positions[BoundsExtentions.LTB] = new Vector3(leftEdge, topEdge, backEdge);
+        positions[BoundsExtentions.RBF] = new Vector3(rightEdge, bottomEdge, frontEdge);
+        positions[BoundsExtentions.RBB] = new Vector3(rightEdge, bottomEdge, backEdge);
+        positions[BoundsExtentions.RTF] = new Vector3(rightEdge, topEdge, frontEdge);
+        positions[BoundsExtentions.RTB] = new Vector3(rightEdge, topEdge, backEdge);
+    }
+
     public static void GetCornerAndMidPointPositions (this Bounds bounds, Transform transform, ref Vector3[] positions)
     {
         // Calculate the local points to transform.

--- a/DesignLabs_Unity_Examples/Assets/MRDesignLab/HUX/Scripts/Interaction/BoundingBox.cs
+++ b/DesignLabs_Unity_Examples/Assets/MRDesignLab/HUX/Scripts/Interaction/BoundingBox.cs
@@ -142,18 +142,14 @@ namespace HUX.Interaction
             // Get the new target bounds
             boundsPoints.Clear();
 
-            MeshFilter[] mfs = target.GetComponentsInChildren<MeshFilter>();
-            foreach (MeshFilter mf in mfs)
+            Renderer[] renderers = target.GetComponentsInChildren<Renderer>();
+            for(int i =0; i<renderers.Length; ++i)
             {
-                if (mf.gameObject.layer == IgnoreLayer)
+                var rendererObj = renderers[i];
+                if(rendererObj.gameObject.layer == IgnoreLayer)
                     continue;
 
-                Vector3 v3Center = mf.sharedMesh.bounds.center;
-                Vector3 v3Extents = mf.sharedMesh.bounds.extents;
-
-                // Get the world-space corner points of the bounds
-                // Add them to our global list of points
-                mf.sharedMesh.bounds.GetCornerPositions(mf.transform, ref corners);
+                rendererObj.bounds.GetCornerPositionsFromRendererBounds(ref corners);
                 boundsPoints.AddRange(corners);
             }
 

--- a/DesignLabs_Unity_Examples/Assets/MRDesignLab/HUX/Scripts/Utility/BoundsExtentions.cs
+++ b/DesignLabs_Unity_Examples/Assets/MRDesignLab/HUX/Scripts/Utility/BoundsExtentions.cs
@@ -94,6 +94,38 @@ public static class BoundsExtentions
         positions[BoundsExtentions.RTB] = transform.TransformPoint(rightEdge, topEdge, backEdge);
     }
 
+    /// <summary>
+    /// Gets all the corner points from Renderer's Bounds
+    /// </summary>
+    /// <param name="bounds"></param>
+    /// <param name="positions"></param>
+    public static void GetCornerPositionsFromRendererBounds(this Bounds bounds, ref Vector3[] positions)
+    {
+        Vector3 center = bounds.center;
+        Vector3 extents = bounds.extents;
+        float leftEdge = center.x - extents.x;
+        float rightEdge = center.x + extents.x;
+        float bottomEdge = center.y - extents.y;
+        float topEdge = center.y + extents.y;
+        float frontEdge = center.z - extents.z;
+        float backEdge = center.z + extents.z;
+
+        const int numPoints = 8;
+        if(positions == null || positions.Length != numPoints)
+        {
+            positions = new Vector3[numPoints];
+        }
+
+        positions[BoundsExtentions.LBF] = new Vector3(leftEdge, bottomEdge, frontEdge);
+        positions[BoundsExtentions.LBB] = new Vector3(leftEdge, bottomEdge, backEdge);
+        positions[BoundsExtentions.LTF] = new Vector3(leftEdge, topEdge, frontEdge);
+        positions[BoundsExtentions.LTB] = new Vector3(leftEdge, topEdge, backEdge);
+        positions[BoundsExtentions.RBF] = new Vector3(rightEdge, bottomEdge, frontEdge);
+        positions[BoundsExtentions.RBB] = new Vector3(rightEdge, bottomEdge, backEdge);
+        positions[BoundsExtentions.RTF] = new Vector3(rightEdge, topEdge, frontEdge);
+        positions[BoundsExtentions.RTB] = new Vector3(rightEdge, topEdge, backEdge);
+    }
+
     public static void GetCornerAndMidPointPositions (this Bounds bounds, Transform transform, ref Vector3[] positions)
     {
         // Calculate the local points to transform.


### PR DESCRIPTION
Hello.

BoundingBox is a very useful asset.

However, for some objects Gizmo is not properly displayed and can not be used, 
for example, using SkinnedMeshRenderer.

This is because Bounds of BoundingBox is calculated based on Bounds obtained from MeshFilter.

So, I propose a method to calculate based on Bounds obtained from Renderer.
Since Bounds that can be obtained from Renderer is world space, I also add extended methods of Bounds.

If you do not mind, try using this code.

Regards.