### PR TITLE
Fixed issue #18 that failed to build on Unity.

### DIFF
--- a/DesignLabs_Unity/Assets/MRDesignLab/HUX/Scripts/Buttons/ButtonIconProfileTexture.cs
+++ b/DesignLabs_Unity/Assets/MRDesignLab/HUX/Scripts/Buttons/ButtonIconProfileTexture.cs
@@ -4,9 +4,6 @@
 //
 using System.Collections.Generic;
 using UnityEngine;
-#if UNITY_WINRT && !UNITY_EDITOR
-#define USE_WINRT
-#endif
 
 namespace HUX.Buttons
 {

--- a/DesignLabs_Unity_Examples/Assets/MRDesignLab/HUX/Scripts/Buttons/ButtonIconProfileTexture.cs
+++ b/DesignLabs_Unity_Examples/Assets/MRDesignLab/HUX/Scripts/Buttons/ButtonIconProfileTexture.cs
@@ -4,9 +4,6 @@
 //
 using System.Collections.Generic;
 using UnityEngine;
-#if UNITY_WINRT && !UNITY_EDITOR
-#define USE_WINRT
-#endif
 
 namespace HUX.Buttons
 {

--- a/DesignLabs_Unity_Examples/Assets/MRDesignLab/HUX/Scripts/Dialogs/SimpleDialogShell.cs
+++ b/DesignLabs_Unity_Examples/Assets/MRDesignLab/HUX/Scripts/Dialogs/SimpleDialogShell.cs
@@ -32,7 +32,7 @@ namespace HUX.Dialogs
         /*[SerializeField]
         private GameObject[] threeButtonSet;*/
 
-        protected override void OnDrawGizmos()
+        protected new void OnDrawGizmos()
         {
             messageText.text = WordWrap(messageText.text, MaxCharsPerLine);
         }


### PR DESCRIPTION
Hello,

I fixed the issue #18. 

I made the same change as "DesignLabs_Unity" in "DesignLabs_Unity_Examples" to SimpleDialogShell.cs.
And,I deleted "#define USE_WINRT" description from ButtonIconProfileTexture.cs.

Merge if you need, please.
Regards.

